### PR TITLE
Adding custom metrics from directory to node exporter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,11 +13,13 @@ services:
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
       - /:/rootfs:ro
+      - /opt/custom_metrics:/metrics:ro
     command:
       - '--path.procfs=/host/proc'
       - '--path.rootfs=/rootfs'
       - '--path.sysfs=/host/sys'
       - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
+      - '--collector.textfile.directory=/metrics'
     restart: unless-stopped
     ports:
       - '9100:9100'


### PR DESCRIPTION
With this, our monitoring will have access to the 'active_kasms' metric, i.e. the number of workspaces currently running on an agent